### PR TITLE
TL;DR -----

### DIFF
--- a/src/terraform/main.tf
+++ b/src/terraform/main.tf
@@ -11,3 +11,14 @@ resource "google_dns_managed_zone" "crdant_cloud" {
     state         = "on"
   }
 }
+
+resource "google_dns_record_set" "crdant_cloud_caa" {
+  name         = google_dns_managed_zone.crdant_cloud.dns_name
+  managed_zone = google_dns_managed_zone.crdant_cloud.name
+  type         = "CAA"
+  ttl          = 300
+
+  rrdatas = [
+    "0 issue letsencrypt.org"
+  ]
+}


### PR DESCRIPTION
Creates a CAA record for the domain

Details
-------

On call with a cutomer last week we talked about CAA records and
I realized this was something I was behind on since none of my
domains have one. This change adds does that for the `crdant.cloud`
domain.
